### PR TITLE
Fix protobuf tag deserialization (wouldn't parse field numbers greater than 31 correctly)

### DIFF
--- a/include/spb/pb/deserialize.hpp
+++ b/include/spb/pb/deserialize.hpp
@@ -153,7 +153,7 @@ static inline void check_if_empty( istream & stream )
         return 0;
     }
     auto byte = uint8_t( byte_or_eof );
-    auto tag  = uint32_t( byte );
+    auto tag  = uint32_t( byte & 0x7F );
 
     for( size_t shift = CHAR_BIT - 1; ( byte & 0x80 ) != 0; shift += CHAR_BIT - 1 )
     {

--- a/test/pb-detail.cpp
+++ b/test/pb-detail.cpp
@@ -135,6 +135,14 @@ using namespace std::literals;
 
 TEST_CASE( "protobuf" )
 {
+    SUBCASE( "tag" )
+    {
+        SUBCASE( "large field numbers" )
+        {
+            pb_test( Test::Scalar::LargeFieldNumber{ "hello" }, "\xa2\x06\x05hello" );
+            pb_test( Test::Scalar::VeryLargeFieldNumber{ "hello" }, "\xfa\xff\xff\xff\x0f\x05hello" );
+        }
+    }
     SUBCASE( "string" )
     {
         SUBCASE( "required" )

--- a/test/proto/scalar/scalar.proto.in
+++ b/test/proto/scalar/scalar.proto.in
@@ -276,3 +276,12 @@ message RepBytesView
 {
     repeated bytes value = 1 [ctype = STRING_PIECE];
 }
+
+message LargeFieldNumber
+{
+    optional string value = 100;
+}
+message VeryLargeFieldNumber
+{
+    optional string value = 536870911; // 2^29 - 1
+}


### PR DESCRIPTION
The varint decoding in read_tag_or_eof was missing the initial bitwise `&` and so it would fail to deserialize any field number greater than 31.