### PR TITLE
Support delimited Protobuf messages

### DIFF
--- a/test/pb.cpp
+++ b/test/pb.cpp
@@ -1978,5 +1978,20 @@ TEST_CASE( "protobuf" )
                     ( void ) spb::pb::deserialize< Test::Scalar::Empty >( "\x07\x05hello"sv ) );
             }
         }
+        SUBCASE( "options" )
+        {
+            SUBCASE( "delimited" )
+            {
+                CHECK( spb::pb::serialize( Test::Scalar::ReqString{ .value = "hello" },
+                                           { .delimited = true } ) == "\x07\x0a\x05hello" );
+                CHECK( spb::pb::serialize( Test::Scalar::Simple{ .value = "hello" },
+                                           { .delimited = true } ) == "\x08\xA2\x06\x05hello" );
+                CHECK( spb::pb::deserialize< Test::Scalar::Simple >( "\x08\xA2\x06\x05hello"sv,
+                                                                     { .delimited = true } ) ==
+                       Test::Scalar::Simple{ .value = "hello" } );
+                CHECK_THROWS( ( void ) spb::pb::deserialize< Test::Scalar::Simple >(
+                    "\x0a\x05hello"sv, { .delimited = true } ) );
+            }
+        }
     }
 }


### PR DESCRIPTION
- Compatible with Google's `writeDelimitedTo` and NanoPb's PB_ENCODE_DELIMITED.
- Passing options as a parameter should not make any difference in speed or stack size given that these functions will be inlined.
- You may have some comments regarding "pb.hpp" now directly calling internal functions such as `deserialize_main`, but solving that would require some minor refactoring, which I thought would be better to do in another pull request.
- I will expand the Readme later.