### PR TITLE
Allow specifying output directory for autogenerated files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required( VERSION 3.12 )
+cmake_minimum_required( VERSION 3.20 )
 
 project(spb-proto VERSION 1.0.0 LANGUAGES CXX)
 
@@ -27,6 +27,12 @@ option(SPB_PROTO_USE_COVERAGE "Enable code coverage" OFF)
 option(SPB_PROTO_USE_ADDRESS_SANITIZER "Enable address sanitizer" OFF)
 option(SPB_PROTO_USE_UB_SANITIZER "Enable undefined behavior sanitizer" OFF)
 
+#[[ 
+  You may specify the output directory for auto-generated files either
+  as an absolute path or relative to CMAKE_SOURCE_DIR.
+  If nothing is set, files will be generated in CMAKE_CURRENT_BINARY_DIR.
+]]
+set(SPB_PROTO_OUTPUT_DIR "" CACHE STRING "Output directory for auto-generated files")
 
 if(SPB_PROTO_USE_COVERAGE)
     find_program(GCOV gcov)

--- a/cmake/spb_protobuf.cmake
+++ b/cmake/spb_protobuf.cmake
@@ -5,6 +5,17 @@ if(SPB_PROTO_USE_CLANG_FORMAT)
 endif()
 
 function(spb_protobuf_generate SRCS HDRS)
+    if (NOT SPB_PROTO_OUTPUT_DIR)
+        set(SPB_PROTO_OUTPUT_DIR ${CMAKE_CURRENT_BINARY_DIR})
+    else()
+        # Convert to absolute path
+        cmake_path(ABSOLUTE_PATH SPB_PROTO_OUTPUT_DIR 
+                BASE_DIRECTORY ${CMAKE_SOURCE_DIR}
+                NORMALIZE
+                OUTPUT_VARIABLE SPB_PROTO_OUTPUT_DIR)
+        file(MAKE_DIRECTORY ${SPB_PROTO_OUTPUT_DIR})
+    endif ()
+    
     if (NOT ARGN)
         message(FATAL_ERROR "Error: spb_protobuf_generate() called without any proto files")
         return()
@@ -19,30 +30,30 @@ function(spb_protobuf_generate SRCS HDRS)
         
         if(TARGET spb-proto)
             # add directory with generated files to the spb-proto includes
-            target_include_directories(spb-proto INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
+            target_include_directories(spb-proto INTERFACE ${SPB_PROTO_OUTPUT_DIR})
         endif()
         
-        list(APPEND ${SRCS} "${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}.pb.cc")
-        list(APPEND ${HDRS} "${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}.pb.h")
+        list(APPEND ${SRCS} "${SPB_PROTO_OUTPUT_DIR}/${FILE_NAME}.pb.cc")
+        list(APPEND ${HDRS} "${SPB_PROTO_OUTPUT_DIR}/${FILE_NAME}.pb.h")
 
-        file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+        file(MAKE_DIRECTORY ${SPB_PROTO_OUTPUT_DIR})
 
         if(SPB_PROTO_USE_CLANG_FORMAT AND CLANG_FORMAT)
             add_custom_command(
-                OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}.pb.cc"
-                       "${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}.pb.h"
-                COMMAND $<TARGET_FILE:spb-protoc> ARGS "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}" ${FILE_ABS}
-                COMMAND ${CLANG_FORMAT} ARGS -i "${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}.pb.cc"
-                COMMAND ${CLANG_FORMAT} ARGS -i "${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}.pb.h"
+                OUTPUT "${SPB_PROTO_OUTPUT_DIR}/${FILE_NAME}.pb.cc"
+                       "${SPB_PROTO_OUTPUT_DIR}/${FILE_NAME}.pb.h"
+                COMMAND $<TARGET_FILE:spb-protoc> ARGS "--cpp_out=${SPB_PROTO_OUTPUT_DIR}" ${FILE_ABS}
+                COMMAND ${CLANG_FORMAT} ARGS -i "${SPB_PROTO_OUTPUT_DIR}/${FILE_NAME}.pb.cc"
+                COMMAND ${CLANG_FORMAT} ARGS -i "${SPB_PROTO_OUTPUT_DIR}/${FILE_NAME}.pb.h"
                 DEPENDS spb-protoc ${FILE_ABS}
                 COMMENT "Compiling protofile ${FIL}"
                 VERBATIM
             )
         else()
             add_custom_command(
-                OUTPUT "${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}.pb.cc"
-                       "${CMAKE_CURRENT_BINARY_DIR}/${FILE_NAME}.pb.h"
-                COMMAND $<TARGET_FILE:spb-protoc> ARGS "--cpp_out=${CMAKE_CURRENT_BINARY_DIR}" ${FILE_ABS}
+                OUTPUT "${SPB_PROTO_OUTPUT_DIR}/${FILE_NAME}.pb.cc"
+                       "${SPB_PROTO_OUTPUT_DIR}/${FILE_NAME}.pb.h"
+                COMMAND $<TARGET_FILE:spb-protoc> ARGS "--cpp_out=${SPB_PROTO_OUTPUT_DIR}" ${FILE_ABS}
                 DEPENDS spb-protoc ${FILE_ABS}
                 COMMENT "Compiling protofile ${FIL}"
                 VERBATIM


### PR DESCRIPTION
- Useful for when you want to commit these files to source control, either in order to be able to track differences in the generated structs, or in order to allow a project to be opened and worked on without first invoking a build step.
- `set CACHE STRING` is used instead of `option` since otherwise IDEs will treat it as a bool.
- Minimum CMake version for the CMake helper function `cmake_path` is version 3.20, which was released in 2021, and so should hopefully be all right to use as a minimum version.